### PR TITLE
Fixed crash on nvme-only machines

### DIFF
--- a/crates/power-daemon/src/profile.rs
+++ b/crates/power-daemon/src/profile.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, io};
 
 use log::{debug, error, info, warn};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -765,8 +765,11 @@ impl SATASettings {
 
         let pm_policy = self.active_link_pm_policy.as_ref().unwrap();
 
-        let entries =
-            fs::read_dir("/sys/class/scsi_host/").expect("Could not read sysfs directory");
+        let entries = match fs::read_dir("/sys/class/scsi_host/") {
+            Ok(itr) => itr,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return,
+            Err(e) => panic!("Could not read sysfs directory: {e:?}"),
+        };
 
         for entry in entries {
             let entry = entry.expect("Could not read sysfs entry");


### PR DESCRIPTION
On my laptop the daemon enters a crash loop with the following logs in systemd: 

```
systemd[1]: Started power-options.service - power-options daemon.
power-daemon-mgr[131776]: INFO ==> [power_daemon_mgr]: Either missing config or missing profiles were detected. Generating them now...
power-daemon-mgr[131776]: ERROR ==> [power_daemon_mgr]: Issue while attempting to generate config/profiles. Exited without success: ExitStatus(unix_wait_status(25856))
systemd[1]: power-options.service: Main process exited, code=exited, status=255/EXCEPTION
systemd[1]: power-options.service: Failed with result 'exit-code'.
```

Investigating further, this was due to my machine missing the `scsi_hosts` device class in sysfs: 

```
$ RUST_BACKTRACE=1 sudo power-daemon-mgr generate-config-files --profiles-only --path /
thread 'main' panicked at crates/power-daemon/src/systeminfo.rs:475:18:
Could not read sysfs dir: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Since my laptop only uses PCI-based NVME storage and not sata I don't have any sata devices to control, causing the crash. To fix this I added a check to see if the `scsi_hosts` directory exists and if not, return that there are no SATA hosts instead of crashing. 