### PR TITLE
Removed zsh dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ chmod +x *.sh
 For *build* dependendencies, refer to the installation guide above.
 
 Mandatory:
-- zsh
 - lspci
 - lsusb
 - acpi

--- a/ci/gen_daemon_pkgbuild.py
+++ b/ci/gen_daemon_pkgbuild.py
@@ -19,7 +19,7 @@ arch=('x86_64')
 url="{url}"
 license=('MIT')
 
-depends=('acpid' 'zsh' 'pciutils' 'usbutils' 'yad')
+depends=('acpid' 'pciutils' 'usbutils' 'yad')
 optdepends=(
 'brightnessctl: needed for brightness settings' 
 'net-tools: needed to disable ethernet cards' 'net-tools: needed to disable ethernet cards'

--- a/ci/gen_daemon_pkgbuild_git.py
+++ b/ci/gen_daemon_pkgbuild_git.py
@@ -24,7 +24,7 @@ arch=('x86_64')
 url="{url}"
 license=('MIT')
 
-depends=('acpid' 'zsh' 'pciutils' 'usbutils' 'yad')
+depends=('acpid' 'pciutils' 'usbutils' 'yad')
 optdepends=(
 'brightnessctl: needed for brightness settings' 
 'net-tools: needed to disable ethernet cards' 'net-tools: needed to disable ethernet cards'

--- a/crates/power-daemon/src/helpers/commands.rs
+++ b/crates/power-daemon/src/helpers/commands.rs
@@ -14,7 +14,7 @@ pub fn command_exists(command: &str) -> bool {
 
 pub fn run_command(command: &str) {
     debug!("running: {command}");
-    let output = Command::new("zsh")
+    let output = Command::new("sh")
         .args(["-c", command])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -56,7 +56,7 @@ pub fn run_command_with_output(command: &str) -> (String, String) {
 pub fn run_graphical_command(command: &str) {
     debug!("running graphical command: {command}");
 
-    let output = Command::new("zsh")
+    let output = Command::new("sh")
         .args(["-c", command])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -81,7 +81,7 @@ pub fn run_graphical_command(command: &str) {
 
 pub fn run_graphical_command_in_background(command: &str) -> std::process::Child {
     debug!("running graphical command in background: {command}");
-    Command::new("zsh")
+    Command::new("sh")
         .args(["-c", command])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
Removes the `zsh` dependency entirely, including from the code, docs, and pkgbuild. 

It was only used due to wildcard issues when trying to run `echo >` into a wildcard path, but now that https://github.com/TheAlexDev23/power-options/pull/13 is merged we won't be doing that anymore. 

