### PR TITLE
Got rid of a lot of subshell calls

### DIFF
--- a/crates/power-daemon/src/profile.rs
+++ b/crates/power-daemon/src/profile.rs
@@ -12,7 +12,11 @@ use crate::{
         WhiteBlackList,
     },
     profiles_generator::{self, DefaultProfileType},
-    sysfs::{gpu::*, reading::file_content_to_string},
+    sysfs::{
+        gpu::*,
+        reading::file_content_to_string,
+        writing::{write_bool, write_str, write_u32},
+    },
     ReducedUpdate, SystemInfo,
 };
 
@@ -277,15 +281,9 @@ impl CPUSettings {
 
         if let Some(ref mode) = self.mode {
             if fs::metadata("/sys/devices/system/cpu/intel_pstate").is_ok() {
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/intel_pstate/status",
-                    mode
-                ))
+                write_str("/sys/devices/system/cpu/intel_pstate/status", mode)
             } else if fs::metadata("/sys/devices/system/cpu/amd_pstate").is_ok() {
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/amd_pstate/status",
-                    mode
-                ))
+                write_str("/sys/devices/system/cpu/amd_pstate/status", mode);
             } else {
                 error!("Scaling driver operation mode is only supported on intel_pstate and amd_pstate drivers.")
             }
@@ -293,12 +291,11 @@ impl CPUSettings {
 
         // Governor and hwp_dynaamic_boost needs to run before epp options because those determine if epp is changable
         if let Some(hwp_dynamic_boost) = self.hwp_dyn_boost {
-            let value = if hwp_dynamic_boost { "1" } else { "0" };
             if fs::metadata("/sys/devices/system/cpu/intel_pstate").is_ok() {
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost",
-                    value
-                ))
+                write_bool(
+                    "/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost",
+                    hwp_dynamic_boost,
+                );
             } else {
                 error!("HWP dynamic boost is currently only supported for intel CPUs with intel_pstate");
             }
@@ -326,16 +323,10 @@ impl CPUSettings {
         if let Some(boost) = self.boost {
             if fs::metadata("/sys/devices/system/cpu/intel_pstate/no_turbo").is_ok() {
                 // using intel turbo
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/intel_pstate/no_turbo",
-                    if boost { '0' } else { '1' }
-                ));
+                write_bool("/sys/devices/system/cpu/intel_pstate/no_turbo", !boost);
             } else if fs::metadata("/sys/devices/system/cpu/cpufreq/boost").is_ok() {
                 // using amd precission boost
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/cpufreq/boost",
-                    if boost { '1' } else { '0' }
-                ));
+                write_bool("/sys/devices/system/cpu/cpufreq/boost", boost);
             } else {
                 error!("CPU boost technology is unsupported by your CPU/driver")
             }
@@ -356,20 +347,20 @@ impl CPUSettings {
 
         if let Some(min_perf_pct) = self.min_perf_pct {
             if fs::metadata("/sys/devices/system/cpu/intel_pstate").is_ok() {
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/intel_pstate/min_perf_pct",
-                    min_perf_pct
-                ))
+                write_u32(
+                    "/sys/devices/system/cpu/intel_pstate/min_perf_pct",
+                    min_perf_pct as u32,
+                );
             } else {
                 error!("Min/Max scaling perf percentage is currently only supported for intel CPUs with intel_pstate");
             }
         }
         if let Some(max_perf_pct) = self.max_perf_pct {
             if fs::metadata("/sys/devices/system/cpu/intel_pstate").is_ok() {
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/intel_pstate/max_perf_pct",
-                    max_perf_pct
-                ))
+                write_u32(
+                    "/sys/devices/system/cpu/intel_pstate/max_perf_pct",
+                    max_perf_pct as u32,
+                );
             } else {
                 error!("Min/Max scaling perf percentage is currently only supported for intel CPUs with intel_pstate");
             }
@@ -452,55 +443,56 @@ impl CPUCoreSettings {
 impl CoreSetting {
     pub fn apply(&self) {
         if let Some(online) = self.online {
-            run_command(&format!(
-                "echo {} > /sys/devices/system/cpu/cpu{}/online",
-                if online { "1" } else { "0" },
-                self.cpu_id,
-            ));
+            write_bool(
+                format!("/sys/devices/system/cpu/cpu{}/online", self.cpu_id),
+                online,
+            );
         }
 
         if let Some(ref epp) = self.epp {
             if fs::metadata("/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference")
                 .is_ok()
             {
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/cpu{}/cpufreq/energy_performance_preference",
-                    epp, self.cpu_id,
-                ));
+                let path = format!(
+                    "/sys/devices/system/cpu/cpu{}/cpufreq/energy_performance_preference",
+                    self.cpu_id
+                );
+                write_str(path, epp);
             } else if fs::metadata("/sys/devices/system/cpu/cpu0/power/energy_perf_bias").is_ok() {
                 debug!(
                     "System does not have EPP but EPB is present, translating and setting EPB..."
                 );
-                run_command(&format!(
-                    "echo {} > /sys/devices/system/cpu/cpu{}/power/energy_perf_bias",
-                    CPUSettings::translate_epp_to_epb(epp),
+                let path = format!(
+                    "/sys/devices/system/cpu/cpu{}/power/energy_perf_bias",
                     self.cpu_id
-                ));
+                );
+                write_str(path, &CPUSettings::translate_epp_to_epb(epp));
             } else {
                 warn!("System does not have EPP or EPB but configuration attempted to set anyways. Ignoring...");
             }
         }
 
         if let Some(ref governor) = self.governor {
-            run_command(&format!(
-                "echo {} > /sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor",
-                governor, self.cpu_id,
-            ));
+            let path = format!(
+                "/sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor",
+                self.cpu_id
+            );
+            write_str(path, governor);
         }
 
         if let Some(min_frequency) = self.min_frequency {
-            run_command(&format!(
-                "echo {} > /sys/devices/system/cpu/cpu{}/cpufreq/scaling_min_freq",
-                min_frequency * 1000,
-                self.cpu_id,
-            ));
+            let path = format!(
+                "/sys/devices/system/cpu/cpu{}/cpufreq/scaling_min_freq",
+                self.cpu_id
+            );
+            write_u32(path, min_frequency * 1000);
         }
         if let Some(max_frequency) = self.max_frequency {
-            run_command(&format!(
-                "echo {} > /sys/devices/system/cpu/cpu{}/cpufreq/scaling_max_freq",
-                max_frequency * 1000,
+            let path = format!(
+                "/sys/devices/system/cpu/cpu{}/cpufreq/scaling_max_freq",
                 self.cpu_id
-            ));
+            );
+            write_u32(path, max_frequency * 1000);
         }
     }
 }
@@ -528,7 +520,7 @@ fn write_all_cores(path: impl AsRef<Path>, data: &str) {
             );
             continue;
         }
-        run_command(&format!("echo {} > {}", data, target.display()));
+        write_str(target, data);
     }
 }
 
@@ -751,10 +743,7 @@ impl ASPMSettings {
         );
 
         if let Some(ref mode) = self.mode {
-            run_command(&format!(
-                "echo {} > /sys/module/pcie_aspm/parameters/policy",
-                mode
-            ));
+            write_str("/sys/module/pcie_aspm/parameters/policy", mode);
         }
     }
 }
@@ -790,11 +779,10 @@ impl PCISettings {
                 self.enable_power_management.unwrap(),
             );
 
-            run_command(&format!(
-                "echo {} > {}",
+            write_str(
+                path.join("power/control"),
                 if enable_pm { "auto" } else { "on" },
-                path.join("power/control").display()
-            ))
+            );
         }
     }
 }
@@ -836,18 +824,14 @@ impl USBSettings {
                     enable_power_management,
                 );
 
-                run_command(&format!(
-                    "echo {} > {}",
+                write_str(
+                    path.join("power/control"),
                     if enable_pm { "auto" } else { "on" },
-                    path.join("power/control").display()
-                ));
+                );
 
                 if enable_pm {
                     if let Some(auto_suspend_ms) = self.autosuspend_delay_ms {
-                        run_command(&format!(
-                            "echo {auto_suspend_ms} > {}",
-                            path.join("power/autosuspend_delay_ms").display()
-                        ));
+                        write_u32(path.join("power/autosuspend_delay_ms"), auto_suspend_ms);
                     }
                 }
             }
@@ -883,10 +867,7 @@ impl SATASettings {
             let entry = entry.expect("Could not read sysfs entry");
             let path = entry.path();
 
-            run_command(&format!(
-                "echo {pm_policy} > {}",
-                path.join("link_power_management_policy").display()
-            ))
+            write_str(path.join("link_power_management_policy"), pm_policy);
         }
     }
 }
@@ -906,19 +887,13 @@ impl KernelSettings {
         );
 
         if let Some(disable_wd) = self.disable_nmi_watchdog {
-            run_command(&format!(
-                "echo {} > /proc/sys/kernel/nmi_watchdog",
-                if disable_wd { "0" } else { "1" }
-            ))
+            write_bool("/proc/sys/kernel/nmi_watchdog", !disable_wd);
         }
         if let Some(vm_writeback) = self.vm_writeback {
-            run_command(&format!(
-                "echo {} > /proc/sys/vm/dirty_writeback_centisecs",
-                vm_writeback * 100
-            ))
+            write_u32("/proc/sys/vm/dirty_writeback_centisecs", vm_writeback * 100);
         }
         if let Some(lm) = self.laptop_mode {
-            run_command(&format!("echo {} > /proc/sys/vm/laptop_mode", lm))
+            write_u32("/proc/sys/vm/laptop_mode", lm);
         }
     }
 }
@@ -932,9 +907,7 @@ pub struct FirmwareSettings {
 impl FirmwareSettings {
     pub fn apply(&self) {
         if let Some(ref profile) = self.platform_profile {
-            run_command(&format!(
-                "echo {profile} > /sys/firmware/acpi/platform_profile"
-            ));
+            write_str("/sys/firmware/acpi/platform_profile", profile);
         }
     }
 }
@@ -948,13 +921,9 @@ impl AudioSettings {
     pub fn apply(&self) {
         if let Some(ref time) = self.idle_timeout {
             if fs::metadata("/sys/module/snd_hda_intel/").is_ok() {
-                run_command(&format!(
-                    "echo {time} > /sys/module/snd_hda_intel/parameters/power_save"
-                ));
+                write_u32("/sys/module/snd_hda_intel/parameters/power_save", *time);
             } else if fs::metadata("/sys/module/snd_ac97_codec/").is_ok() {
-                run_command(&format!(
-                    "echo {time} > /sys/module/snd_ac97_codec/parameters/power_save"
-                ));
+                write_u32("/sys/module/snd_ac97_codec/parameters/power_save", *time);
             } else {
                 error!("Attempted to set audio idle timeout but only snd_hda_intel and snd_ac97_codec modules are supported for this feature.");
             }

--- a/crates/power-daemon/src/sysfs/gpu.rs
+++ b/crates/power-daemon/src/sysfs/gpu.rs
@@ -3,9 +3,12 @@ use std::{
     path::PathBuf,
 };
 
-use crate::helpers::{run_command, run_command_with_output};
+use crate::helpers::run_command_with_output;
 
-use super::reading::{file_content_to_string, file_content_to_u32};
+use super::{
+    reading::{file_content_to_string, file_content_to_u32},
+    writing::{write_str, write_u32},
+};
 
 pub struct IntelGpu {
     pub min_frequency: u32,
@@ -26,22 +29,13 @@ impl IntelGpu {
     }
 
     pub fn set_min(&self, min: u32) {
-        run_command(&format!(
-            "echo {min} > {}",
-            self.path.join("gt_min_freq_mhz").display()
-        ));
+        write_u32(self.path.join("gt_min_freq_mhz"), min);
     }
     pub fn set_max(&self, max: u32) {
-        run_command(&format!(
-            "echo {max} > {}",
-            self.path.join("gt_max_freq_mhz").display()
-        ));
+        write_u32(self.path.join("gt_max_freq_mhz"), max);
     }
     pub fn set_boost(&self, boost: u32) {
-        run_command(&format!(
-            "echo {boost} > {}",
-            self.path.join("gt_boost_freq_mhz").display()
-        ));
+        write_u32(self.path.join("gt_boost_freq_mhz"), boost);
     }
 }
 
@@ -103,23 +97,19 @@ impl AmdGpu {
     pub fn set_dpm_perf_level(&self, perf_level: &str) {
         match &self.driver {
             AmdGpuDriver::AmdGpu { dpm_perf: _ } => {
-                run_command(&format!(
-                    "echo {perf_level} > {}",
-                    self.path
-                        .join("device/power_dpm_force_performance_level")
-                        .display()
-                ));
+                write_str(
+                    self.path.join("device/power_dpm_force_performance_level"),
+                    perf_level,
+                );
             }
             AmdGpuDriver::Radeon {
                 dpm_perf: _,
                 dpm_state: _,
             } => {
-                run_command(&format!(
-                    "echo {perf_level} > {}",
-                    self.path
-                        .join("device/power_dpm_force_performance_level")
-                        .display()
-                ));
+                write_str(
+                    self.path.join("device/power_dpm_force_performance_level"),
+                    perf_level,
+                );
             }
             AmdGpuDriver::Legacy { power_profile: _ } => {}
         }
@@ -132,10 +122,7 @@ impl AmdGpu {
                 dpm_perf: _,
                 dpm_state: _,
             } => {
-                run_command(&format!(
-                    "echo {power_state} > {}",
-                    self.path.join("device/power_dpm_state").display()
-                ));
+                write_str(self.path.join("device/power_dpm_state"), power_state);
             }
             AmdGpuDriver::Legacy { power_profile: _ } => {}
         }
@@ -149,14 +136,8 @@ impl AmdGpu {
                 dpm_state: _,
             } => {}
             AmdGpuDriver::Legacy { power_profile: _ } => {
-                run_command(&format!(
-                    "echo profile > {}",
-                    self.path.join("device/power_method").display()
-                ));
-                run_command(&format!(
-                    "echo {power_profile} > {}",
-                    self.path.join("power_profile").display()
-                ));
+                write_str(self.path.join("device/power_method"), "profile");
+                write_str(self.path.join("power_profile"), power_profile);
             }
         }
     }

--- a/crates/power-daemon/src/sysfs/mod.rs
+++ b/crates/power-daemon/src/sysfs/mod.rs
@@ -1,2 +1,3 @@
 pub mod gpu;
 pub mod reading;
+pub mod writing;

--- a/crates/power-daemon/src/sysfs/writing.rs
+++ b/crates/power-daemon/src/sysfs/writing.rs
@@ -1,0 +1,56 @@
+use std::{
+    fs,
+    io::{self, Write},
+    path::Path,
+};
+
+use log::{debug, error, warn};
+
+/// Writes a bool value to a /sys path, mapping `true` to "1" and `false` to
+/// "0".
+///
+/// Logs when encountering an error but does not crash. 
+pub fn write_bool(path: impl AsRef<Path>, value: bool) {
+    let payload = if value { "1" } else { "0" };
+    write_str(path, payload)
+}
+
+/// Writes a u32 value to a /sys path.
+///
+/// Logs when encountering an error but does not crash. 
+pub fn write_u32(path: impl AsRef<Path>, value: u32) {
+    let payload = value.to_string();
+    write_str(path, &payload)
+}
+
+/// Writes a string value to a /sys path.
+///
+/// Logs when encountering an error but does not crash. 
+pub fn write_str(path: impl AsRef<Path>, payload: &str) {
+    let path = path.as_ref();
+    match write_str_inner(path, payload) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            warn!(
+                "Attempted to write \"{payload}\" to {}, but path does not exist!",
+                path.display()
+            );
+        }
+        Err(e) => {
+            error!(
+                "Error writing \"{payload}\" to path {}: {e:?}",
+                path.display()
+            );
+        }
+    }
+}
+
+
+fn write_str_inner(path: impl AsRef<Path>, payload: &str) -> io::Result<()> {
+    let path = path.as_ref();
+    debug!("Writing payload \"{payload}\" to path {}", path.display());
+    let mut fh = fs::File::options().write(true).truncate(true).open(path)?;
+    fh.write_all(payload.as_bytes())?;
+    fh.flush()?;
+    Ok(())
+}


### PR DESCRIPTION
Replaced a lot of subshell calls with normal, in-process syscalls. 

Specifically: 
* Calls to `echo {} > {}` have been replaced with new `write_` helper functions for writing either `str`s, `u32`s, or `bool` values. This mirrors the existing helpers in `sysfs::reading`. 
* Calls to `readlink {}` have been replaced with the `std::fs::read_link` function.

Implications: 
* The only places left where we actually need to use a subshell (as opposed to a shell-independent `Command` call) are: 
    *  Refreshing the kernel modules in `NetworkSettings::apply_kernel_module_settings`, since we currently remove & add 2 modules in a single command (instead of 4 different subprocesses)
    * Pulling out the PCI information in `PCIInfo::obtain`, where we use a `sed` block to filter & parse the output of `lspci -s`. 